### PR TITLE
448 Add errors for missing dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ word_id_score.json
 access_word_id.json
 personName_ids.json 
 type_ids.json
+suggestions.json
 # generated from pubdb
 sources/*/*__pubdb.json
 sources/*/*__externallinks.json

--- a/scripts/data-build.py
+++ b/scripts/data-build.py
@@ -484,10 +484,16 @@ def object_date_add(obj):
     today = datetime.date.today().strftime("%Y-%m")
 
     if obj["__typename"] == "Venue":
-        if "dates" in obj:
+        if "dates" in obj and len(obj['dates']) >= 1:
             for date_url in obj["dates"]:
                 if "date" not in obj or obj["date"] < date_url["date"]:
                     obj["date"] = utils.date_parse(date_url["date"])
+        else:
+            if "date" not in obj:
+                if "deprecated" in obj:
+                    utils.warning_add(obj["filename"], "missing date(s), but is deprecated")
+                else:
+                    utils.error_add(obj["filename"], "missing date(s), please add date(s)")
     else:
         for key, value in obj.items():
             if key[:4] == "date" and type(value) == str:
@@ -540,6 +546,11 @@ def object_date_add(obj):
                     person_venue["venue"] = id_object[vid]["name"]
                 else:
                     utils.error_add(obj["filename"], f'missing venue: {person_venue["venue"]}')
+        if "date" not in obj:
+            if "deprecated" in obj:
+                utils.warning_add(obj["filename"], "missing date, but is deprecated")
+            else:
+                utils.error_add(obj["filename"], "missing date, please add date")
     else:
         if "date" not in obj:
             obj["date"] = None

--- a/scripts/data-build.py
+++ b/scripts/data-build.py
@@ -523,12 +523,12 @@ def object_date_add(obj):
                 id_date[obj["id"]] = {}
     
     # change date start to dateCreated for software
-    if obj["__typename"] == "Software":
-        if "dateCreated" not in obj and "dateModified" not in obj:
-            if "deprecated" in obj:
-                utils.warning_add(obj["filename"], "missing dateCreated and dateModified, but is deprecated")
-            else:
-                utils.error_add(obj["filename"], "missing dateCreated and dateModified, please add dateCreated or dateModified")
+    #if obj["__typename"] == "Software":
+    #    if "dateCreated" not in obj and "dateModified" not in obj:
+    #        if "deprecated" in obj:
+    #            utils.warning_add(obj["filename"], "missing dateCreated and dateModified, but is deprecated")
+    #        else:
+    #            utils.error_add(obj["filename"], "missing dateCreated and dateModified, please add dateCreated or dateModified")
     
     if obj["__typename"] == "Media" and "presenters" in obj:
         for person_venue in obj["presenters"]:
@@ -557,6 +557,11 @@ def object_date_add(obj):
                 if key in obj:
                     obj["date"] = obj[key]
                     break
+            if obj["date"] is None:
+                if "deprecated" in obj:
+                    utils.warning_add(obj["filename"], "missing " + ", ".join(type_key[type_]) + ", but is deprecated")
+                else:
+                    utils.error_add(obj["filename"], "missing " + ", ".join(type_key[type_]) + ", please add " + ", ".join(type_key[type_]))
     
 
     #for dst,src in [["dateCreated","dateObjectCreated"], ["dateLastModified","dateObjectModified"]]:

--- a/scripts/data-build.py
+++ b/scripts/data-build.py
@@ -525,7 +525,10 @@ def object_date_add(obj):
     # change date start to dateCreated for software
     if obj["__typename"] == "Software":
         if "dateCreated" not in obj and "dateModified" not in obj:
-            utils.error_add(obj["filename"], "missing dateCreated and dateModified, please add dateCreated or dateModified")
+            if "deprecated" in obj:
+                utils.warning_add(obj["filename"], "missing dateCreated and dateModified, but is deprecated")
+            else:
+                utils.error_add(obj["filename"], "missing dateCreated and dateModified, please add dateCreated or dateModified")
     
     if obj["__typename"] == "Media" and "presenters" in obj:
         for person_venue in obj["presenters"]:


### PR DESCRIPTION
Within data-build.py, add errors for missing dates for all types of objects and add warnings for deprecated objects that are missing dates. Also, add suggestions.json to gitignore.