### PR TITLE
643 all access objects should have types

### DIFF
--- a/scripts/data-build.py
+++ b/scripts/data-build.py
@@ -550,9 +550,12 @@ def main():
     # copy out doi && pull out access tag to access type
     #######################
     print ("Pulling DOIs out of access && pull out access tag to access type")
+    count_access_no_tags = 0
     for obj in id_object.values():
         doi_set(obj)
-        access_type_from_tag_set(obj)
+        count_access_no_tags += access_type_from_tag_set(obj)
+    if count_access_no_tags > 0:
+        utils.error_add("", '%s Objects that are missing a tags and type; please add a type to each access object.' % count_access_no_tags)
 
     #######################
     # printing errors
@@ -2102,14 +2105,20 @@ def doi_set(obj):
 
 ## Helper function pulls out first access tag and creates access type
 def access_type_from_tag_set(obj):
+    curr_id = obj["id"]
+    count = 0
     if "access" not in obj:
-        return 
+        return count
     else:
         # for each access in an object
         for curr_access in obj["access"]:
             # ignore if no tags
             if "tags" not in curr_access or "type" in curr_access:
+                if "tags" not in curr_access and "type" not in curr_access:
+                    utils.error_add(obj['filename'], "access does not have tags or type")
+                    count += 1
                 continue
+                
             else:
                 new_type = curr_access["tags"][0]
                 if len(new_type.split(':')) != 2:
@@ -2117,7 +2126,7 @@ def access_type_from_tag_set(obj):
                 else:
                     # remove the "tag:" from the tag
                     curr_access["type"] = curr_access["tags"][0].split(':')[1].replace("_", " ")
-        return 
+        return count
         
 
 def papers_access_add_same_name():

--- a/sources/dataset/iana_asn_allocations.json
+++ b/sources/dataset/iana_asn_allocations.json
@@ -8,7 +8,8 @@
     "access": [
         {
             "access": "public/restricted",
-            "url": "https://www.iana.org/assignments/as-numbers/as-numbers.xhtml"
+            "url": "https://www.iana.org/assignments/as-numbers/as-numbers.xhtml",
+            "type": "direct download"
         }
     ],
     "tags": [

--- a/sources/dataset/maxmind_geolite.json
+++ b/sources/dataset/maxmind_geolite.json
@@ -13,11 +13,13 @@
     "access": [
         {
             "access": "discontinued",
-            "url": "https://dev.maxmind.com/geoip/release-notes/2018#discontinuation-of-the-geolite-legacy-databases"
+            "url": "https://dev.maxmind.com/geoip/release-notes/2018#discontinuation-of-the-geolite-legacy-databases",
+            "type": "archive"
         },
         {
             "access": "public",
-            "url": "https://dev.maxmind.com/geoip/geolite2-free-geolocation-data"
+            "url": "https://dev.maxmind.com/geoip/geolite2-free-geolocation-data",
+            "type": "webpage"
         }
     ]
 }

--- a/sources/dataset/mopeye.json
+++ b/sources/dataset/mopeye.json
@@ -12,7 +12,8 @@
     "access": [
         {
             "access": "public",
-            "url": "https://github.com/VPRLab/mopeyeDataset"
+            "url": "https://github.com/VPRLab/mopeyeDataset",
+            "type": "direct download"
         }
     ]
 }

--- a/sources/dataset/netacuity_edge.json
+++ b/sources/dataset/netacuity_edge.json
@@ -16,7 +16,8 @@
     "access": [
         {
             "access": "restricted",
-            "url": "https://www.digitalelement.com/solutions/ip-location-targeting/"
+            "url": "https://www.digitalelement.com/solutions/ip-location-targeting/",
+            "type": "webpage"
         }
     ]
 }

--- a/sources/dataset/peeringdb.json
+++ b/sources/dataset/peeringdb.json
@@ -13,7 +13,10 @@
     "access": [
         {
             "access": "public",
-            "url": "https://www.peeringdb.com/"
+            "url": "https://www.peeringdb.com/",
+            "tags": [
+                "webpage"
+            ]
         },
         {
             "access": "public",

--- a/sources/dataset/thunderping.json
+++ b/sources/dataset/thunderping.json
@@ -20,7 +20,8 @@
     "access": [
         {
             "access": "restricted",
-            "url": "https://cseweb.ucsd.edu//~schulman/thunderping.html"
+            "url": "https://cseweb.ucsd.edu//~schulman/thunderping.html",
+            "type": "webpage"
         }
     ]
 }


### PR DESCRIPTION
Closes #643 
- Based on the [UI Issue](https://github.com/CAIDA/catalog-ui/issues/775) the "type" field in "access" must always exist in the data. 
- Now, if there is no tags field in access, I have found the file and added a "type" to the access
- I have also added an error message if an access object doesn't have a "type" field