### PR TITLE
doi field is now case insensitive

### DIFF
--- a/scripts/pubdb_placeholder.py
+++ b/scripts/pubdb_placeholder.py
@@ -102,7 +102,7 @@ def main():
         if "links" in obj:
             access = []
             for link in obj["links"]:
-                if link["label"] == "DOI":
+                if link["label"].upper() == "DOI":
                     obj["doi"] = link["to"]
                     continue
                    


### PR DESCRIPTION
### Before merging:

* [x] Have you checked the diffs (of new code) for stray console logs, and removed them?
* [x] Have you checked the diffs (of new code) for un-used imports and comments, and removed them?
* [x] Have you tested edge cases that you have thought of? (when the variable is undefined, invalid TYPE, when there are many items in an array, when there are very few)

## Issue

Before, when the `doi` field was case sensitive, part of the output for a given paper with the link associated with `doi` instead of `DOI` in the `id_object.json` file was as follows:
```
"access": [
            {
                "access": "public",
                "url": "https://doi.org/10.1145/3618257.3624838",
                "type": "doi"
            },
            {
                "access": "public",
                "url": "https://www.caida.org/catalog/papers/2023_coarse_grained_inference_bgp/coarse_grained_inference_bgp.pdf",
                "type": "PDF"
            }
        ],
```
The doi associated url should be its own field outside of the access array.

## Fix
After making the script check for `DOI` regardless of case (using .upper() method), the output for a given paper, where the `doi` field is not fully uppercase, was correct:
```
"doi": "https://doi.org/10.1145/3618257.3624838",
"access": [
    {
        "access": "public",
        "url": "https://www.caida.org/catalog/papers/2023_coarse_grained_inference_bgp/coarse_grained_inference_bgp.pdf",
        "type": "PDF"
    }
],
```

### Notes
- Now, doi can be spelled regardless of any case: doi, DOI, dOi, Doi, etc.
- Did not pull the catalog-data repository when making these changes, but the lack of the repository did not change expected issue or fix