### PR TITLE
Fixing typos in Ontology Data

### DIFF
--- a/ontology/AsnLinkRelationshipNamespace.md
+++ b/ontology/AsnLinkRelationshipNamespace.md
@@ -17,5 +17,5 @@
 ===schema:description
 Although business agreements between ISPs can be complicated, the original model introduced by Gao 
 abstracts business relationships into the following three most common types:
-<b>Customer</b> ASN0 is a the customer of ASN1, <b>Provider</b> ASN1 is the provider of ASN1,
-<b>Peer</b> ASN1 and ASN2 are peers, and <b>Silbing</b> ASN1 and ASN2 are siblings.
+<b>Customer</b> ASN0 is the customer of ASN1, <b>Provider</b> ASN1 is the provider of ASN1,
+<b>Peer</b> ASN1 and ASN2 are peers, and <b>Sibling</b> ASN1 and ASN2 are siblings.

--- a/ontology/AsnNumberNamespace.md
+++ b/ontology/AsnNumberNamespace.md
@@ -20,7 +20,7 @@ prefixes under the control of one or more network operators on behalf of a
 single administrative entity or domain, that presents a common and clearly
 defined routing policy to the Internet. Until 2007, AS numbers were 16-bit
 unsigned integers with a range from 0 to 65,536. In 2007, AS numbers were
-expaned to 32-bit unsigned integers creating a theoretical range from 0 
+expanded to 32-bit unsigned integers creating a theoretical range from 0 
 to 4,294,967,295. This range is contrasted by a set of reserved blocks, 
 limiting the set of available AS numbers.
 

--- a/ontology/NamespaceProperty.json
+++ b/ontology/NamespaceProperty.json
@@ -16,7 +16,7 @@
         "@id": "caida:NamespaceProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "schema:Url"
+        "@id": "schema:URL"
       }
     },
     {
@@ -26,7 +26,7 @@
         "@id": "caida:NamespaceProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "schema:Url"
+        "@id": "schema:URL"
       }
     },
     {

--- a/ontology/PropertyMap.json
+++ b/ontology/PropertyMap.json
@@ -16,7 +16,7 @@
         "@id": "caida:PropertyMap"
       },
       "schema:rangeIncludes": {
-        "@id": "schema:Url"
+        "@id": "schema:URL"
       }
     },
     {
@@ -26,7 +26,7 @@
         "@id": "caida:PropertyMap"
       },
       "schema:rangeIncludes": {
-        "@id": "schema:Url"
+        "@id": "schema:URL"
       }
     },
     {


### PR DESCRIPTION
From this issue #728, fixed typos in the ontology data that appear on the main page (/ontology)