### PR TITLE
Restore Two Entries Marked as False Negatives to True Positives

### DIFF
--- a/data/data-papers.yaml
+++ b/data/data-papers.yaml
@@ -71486,3 +71486,29 @@ YEAR: 2024-07
 URL: 10.5220/0012794400003767
 TOPKEY: ddos-2007
 GEOLOC: Regina, CA
+---
+MARKER: 2020_smathers_k_afitedu_41902020
+TYPE: mastersthesis
+AUTHOR: Smathers, K.
+TITLE: A General Methodology To Optimize And Benchmark Edge Devices
+PUBLISH: Air Force Institute of Technology
+PAGE: 1-181
+YEAR: 2020-03
+URL: https://scholar.afit.edu/cgi/viewcontent.cgi?article=4190&context=etd
+TOPKEY: passive-stats
+GEOLOC: Greene County, OH, US
+ABS: ''
+---
+MARKER: 2020_shrishak_k_acm_3406674
+TYPE: inproceedings
+AUTHOR: Shrishak, K., Shulman, H.
+TITLE: Limiting the Power of RPKI Authorities
+CTITLE: Proceedings of the Applied Networking Research Workshop (ANRW '20)
+YEAR: 2020-07
+VOLUME: ''
+PAGE: 12-18
+DOI: 10.1145/3404868.3406674
+URL: https://dl.acm.org/doi/abs/10.1145/3404868.3406674
+TOPKEY: topology-as-relationships
+GEOLOC: Darmstadt, DE
+ABS: ''

--- a/data/data-papers.yaml
+++ b/data/data-papers.yaml
@@ -13380,7 +13380,7 @@ TOPKEY: passive-2016
 GEOLOC: Zhengzhou, CN
 ABS: ''
 ---
-MARKER: 2020)fukushi_n_ieee_9162303
+MARKER: 2020_fukushi_n_ieee_9162303
 TYPE: inproceedings
 AUTHOR: Fukushi, N., Chiba, D., Akiyama, M., Uchida, M.
 TITLE: A Large-scale Analysis of Cloud Service Abuse


### PR DESCRIPTION
## Details
This PR restores two entries that were previously deleted in commit [8356b1f](https://github.com/CAIDA/catalog-data/commit/8356b1fea43d5633bd474c47637963f67ce12bc6). These entries were mistakenly identified as false negatives but should be classified as true positives.
## Changes
- Re-added the two entries to the dataset
- Ensured they are correctly classified as true positives